### PR TITLE
Increase selenium for java11

### DIFF
--- a/galen-core/pom.xml
+++ b/galen-core/pom.xml
@@ -47,6 +47,11 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
       <version>${selenium.version}</version>

--- a/galen-core/src/main/java/com/galenframework/reports/GalenTestInfo.java
+++ b/galen-core/src/main/java/com/galenframework/reports/GalenTestInfo.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import com.galenframework.tests.GalenEmptyTest;
 import com.galenframework.tests.GalenTest;
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.commons.lang3.StringEscapeUtils;
 
 public class GalenTestInfo {

--- a/galen-core/src/test/java/com/galenframework/components/mocks/driver/MockedPageItem.java
+++ b/galen-core/src/test/java/com/galenframework/components/mocks/driver/MockedPageItem.java
@@ -74,7 +74,7 @@ public class MockedPageItem {
 
     public boolean matches(By by) {
         if (by instanceof By.ByCssSelector) {
-            String selector = (String)takeFieldValueViaReflection(by, "selector");
+            String selector = (String)takeFieldValueViaReflection(by, "cssSelector");
             if("css".equals(getLocatorType()) && selector.equals(getLocatorValue()) ) {
                 return true;
             }

--- a/galen-core/src/test/java/com/galenframework/tests/validation/ImageValidationTest.java
+++ b/galen-core/src/test/java/com/galenframework/tests/validation/ImageValidationTest.java
@@ -91,7 +91,7 @@ public class ImageValidationTest extends ValidationTestBase {
 
             {new ValidationResult(NO_SPEC, areas(new ValidationObject(new Rect(100, 90, 100, 40), "object")),
                     new ValidationError(messages("Element does not look like \"/imgs/button-sample-incorrect.png\". " +
-                        "There are 95.5% mismatching pixels but max allowed is 2%"))),
+                        "There are 95,5% mismatching pixels but max allowed is 2%"))),
                 specImage(asList("/imgs/button-sample-incorrect.png"), 2.0, PERCENTAGE_UNIT, 0, 10), page(new HashMap<String, PageElement>() {{
                     put("object", element(100, 90, 100, 40));
                 }}, imageComparisonTestScreenshot)},

--- a/galen-core/src/test/java/com/galenframework/tests/validation/ImageValidationTest.java
+++ b/galen-core/src/test/java/com/galenframework/tests/validation/ImageValidationTest.java
@@ -91,7 +91,7 @@ public class ImageValidationTest extends ValidationTestBase {
 
             {new ValidationResult(NO_SPEC, areas(new ValidationObject(new Rect(100, 90, 100, 40), "object")),
                     new ValidationError(messages("Element does not look like \"/imgs/button-sample-incorrect.png\". " +
-                        "There are 95,5% mismatching pixels but max allowed is 2%"))),
+                        "There are 95.5% mismatching pixels but max allowed is 2%"))),
                 specImage(asList("/imgs/button-sample-incorrect.png"), 2.0, PERCENTAGE_UNIT, 0, 10), page(new HashMap<String, PageElement>() {{
                     put("object", element(100, 90, 100, 40));
                 }}, imageComparisonTestScreenshot)},

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
 
     <!-- VERSION NUMBERS -->
-    <selenium.version>3.11.0</selenium.version>
+    <selenium.version>3.14.0</selenium.version>
     <commons-io.version>2.4</commons-io.version>
     <commons-cli.version>1.2</commons-cli.version>
     <phantomjsdriver.version>1.2.1</phantomjsdriver.version>


### PR DESCRIPTION
Increased Selenium to 3.14.0 to get bytebuddy 1.18.5 and Java 11 support. Fixed some failing tests.